### PR TITLE
First pass at BigQuery table schema

### DIFF
--- a/cmip6-schema.json
+++ b/cmip6-schema.json
@@ -81,6 +81,6 @@
     "description": "version",
     "mode": "REQUIRED",
     "name": "version",
-    "type": "INT64"
+    "type": "STRING"
   }
 ]

--- a/cmip6-schema.json
+++ b/cmip6-schema.json
@@ -1,63 +1,75 @@
 [
   {
-    "description": "activity ID",
+    "description": "activity identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "activity_id",
     "type": "STRING"
   },
   {
-    "description": "institution ID",
+    "description": "institution identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "institution_id",
     "type": "STRING"
   },
   {
-    "description": "source ID",
+    "description": "model identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "source_id",
     "type": "STRING"
   },
   {
-    "description": "experiment ID",
+    "description": "root experiment identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "experiment_id",
     "type": "STRING"
   },
   {
-    "description": "member ID",
-    "mode": "REQUIRED",
-    "name": "member_id",
+    "description": "sub-experiment identifier (part of DRS member_id)",
+    "mode": "NULLABLE",
+    "name": "sub_experiment_id",
     "type": "STRING"
   },
   {
-    "description": "table ID",
+    "description": "variant label (part of DRS member_id)",
+    "mode": "REQUIRED",
+    "name": "variant_label",
+    "type": "STRING"
+  },
+  {
+    "description": "table identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "table_id",
     "type": "STRING"
   },
   {
-    "description": "variable ID",
+    "description": "variable identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "variable_id",
     "type": "STRING"
   },
   {
-    "description": "grid label",
+    "description": "grid identifier (part of DRS)",
     "mode": "REQUIRED",
     "name": "grid_label",
     "type": "STRING"
   },
   {
-    "description": "Zarr store location",
+    "description": "Zarr store location in cloud storage",
     "mode": "REQUIRED",
     "name": "zstore",
     "type": "STRING"
   },
   {
-    "description": "DCPP start year",
-    "mode": "NULLABLE",
-    "name": "dcpp_start_year",
-    "type": "INT64"
+    "description": "Unique ID to reference all years of the same variable of a particular version of a run",
+    "mode": "REQUIRED",
+    "name": "dataset_tracking_id",
+    "type": "STRING"
+  },
+  {
+    "description": "All of the netCDF tracking IDs that have gone into this record",
+    "mode": "REPEATED",
+    "name": "netcdf_tracking_ids",
+    "type": "STRING"
   },
   {
     "description": "status",

--- a/cmip6-schema.json
+++ b/cmip6-schema.json
@@ -24,6 +24,12 @@
     "type": "STRING"
   },
   {
+    "description": "compound construction from sub_experiment_id and variant_label",
+    "mode": "REQUIRED",
+    "name": "member_id",
+    "type": "STRING"
+  },
+  {
     "description": "sub-experiment identifier (part of DRS member_id)",
     "mode": "NULLABLE",
     "name": "sub_experiment_id",

--- a/cmip6-schema.json
+++ b/cmip6-schema.json
@@ -1,0 +1,86 @@
+[
+  {
+    "description": "activity ID",
+    "mode": "REQUIRED",
+    "name": "activity_id",
+    "type": "STRING"
+  },
+  {
+    "description": "institution ID",
+    "mode": "REQUIRED",
+    "name": "institution_id",
+    "type": "STRING"
+  },
+  {
+    "description": "source ID",
+    "mode": "REQUIRED",
+    "name": "source_id",
+    "type": "STRING"
+  },
+  {
+    "description": "experiment ID",
+    "mode": "REQUIRED",
+    "name": "experiment_id",
+    "type": "STRING"
+  },
+  {
+    "description": "member ID",
+    "mode": "REQUIRED",
+    "name": "member_id",
+    "type": "STRING"
+  },
+  {
+    "description": "table ID",
+    "mode": "REQUIRED",
+    "name": "table_id",
+    "type": "STRING"
+  },
+  {
+    "description": "variable ID",
+    "mode": "REQUIRED",
+    "name": "variable_id",
+    "type": "STRING"
+  },
+  {
+    "description": "grid label",
+    "mode": "REQUIRED",
+    "name": "grid_label",
+    "type": "STRING"
+  },
+  {
+    "description": "Zarr store location",
+    "mode": "REQUIRED",
+    "name": "zstore",
+    "type": "STRING"
+  },
+  {
+    "description": "DCPP start year",
+    "mode": "NULLABLE",
+    "name": "dcpp_start_year",
+    "type": "INT64"
+  },
+  {
+    "description": "status",
+    "mode": "REQUIRED",
+    "name": "status",
+    "type": "STRING"
+  },
+  {
+    "description": "severity",
+    "mode": "NULLABLE",
+    "name": "severity",
+    "type": "STRING"
+  },
+  {
+    "description": "issue URL",
+    "mode": "NULLABLE",
+    "name": "issue_url",
+    "type": "STRING"
+  },
+  {
+    "description": "version",
+    "mode": "REQUIRED",
+    "name": "version",
+    "type": "INT64"
+  }
+]


### PR DESCRIPTION
First attempt at defining a BigQuery table schema for our CMIP6 data, based on `cmip6-zarr-consolidated-stores-noQC.csv`. Some observations:

- I defined `dcpp_start_year` as an integer field, but noticed all the dates were formatted as floats (i.e. `1989.0`); is there a potential need for float based values here?
- Are `serious` issues defined by: 
  - a non-null value for `severity`?
  - a value that is NOT `good` or `resolved` for `status`?
  - some combination of the two?
- I defined `version` as an integer field, as all values for this field corresponded to dates - would it be worthwhile to redefine this field as a BigQuery `DATE`, keep it as is, or even redefine it as a `STRING` to broaden the field?